### PR TITLE
Feature/13 more robust fulltext search with postgres in generator

### DIFF
--- a/lib/mix/tasks/rag.gen_rag_module.ex
+++ b/lib/mix/tasks/rag.gen_rag_module.ex
@@ -157,11 +157,9 @@ defmodule Mix.Tasks.Rag.GenRagModule do
       end
 
       defp query_fulltext(%{query: query}, limit \\\\ 3) do
-        query = query |> String.trim() |> String.replace(" ", " & ")
-
         {:ok, Repo.all(
           from(c in #{inspect(schema_module)},
-            where: fragment("to_tsvector(?) @@ to_tsquery(?)", c.document, ^query),
+            where: fragment("to_tsvector(?) @@ websearch_to_tsquery(?)", c.chunk, ^query),
             limit: ^limit
           )
         )}


### PR DESCRIPTION
Replaces `to_tsquery` with `websearch_to_tsquery` so we don't run into syntax errors.
Performs fulltext search in chunks instead of full documents.