### PR TITLE
Add possibility to add a reference for telemetry

### DIFF
--- a/lib/rag/generation.ex
+++ b/lib/rag/generation.ex
@@ -21,7 +21,8 @@ defmodule Rag.Generation do
           response: String.t() | nil,
           evaluations: %{optional(atom()) => any()},
           halted?: boolean(),
-          errors: list(any())
+          errors: list(any()),
+          ref: any()
         }
 
   @enforce_keys [:query]
@@ -34,13 +35,17 @@ defmodule Rag.Generation do
             response: nil,
             evaluations: %{},
             halted?: false,
-            errors: []
+            errors: [],
+            ref: nil
 
   @doc """
   Creates a new generation struct from a query.
   """
-  @spec new(String.t()) :: t()
-  def new(query) when is_binary(query), do: %Generation{query: query}
+  @spec new(String.t(), opts :: keyword()) :: t()
+  def new(query, opts \\ []) when is_binary(query) do
+    ref = Keyword.get(opts, :ref)
+    %Generation{query: query, ref: ref}
+  end
 
   @doc """
   Puts `query_embedding` in `generation.query_embedding`.


### PR DESCRIPTION
Currently there is no way to reference the generations back to anythin in the telemetry events. 
One could match on the query, but that does not work all too well. So in order for the telemetry 
events to make sense, we want to store something on the generation, that is then reported back with the metadata.